### PR TITLE
plugin activation hook update

### DIFF
--- a/photonfill.php
+++ b/photonfill.php
@@ -27,7 +27,7 @@ add_action( 'plugins_loaded', 'photonfill_init' );
 
 function photonfill_dependency() {
 	$photonfill_dependency = new Plugin_Dependency( 'Jetpack', 'Jetpack by WordPress.com', 'http://jetpack.me/' );
-	if ( ! $photonfill_dependency->verify() ) {
+	if ( ! class_exists( 'Jetpack' ) ) {
 		// Cease activation
 	 	die( $photonfill_dependency->message() );
 	}


### PR DESCRIPTION
Right now photonfill cannot be activated if Jetpack is installed as an MU plugin, because the plugin dependency checker checks the "active_plugins" option in the database, which doesn't include mu-plugins. So, the activation hook is preventing the plugin from being loaded even if Jetpack actually is active. 

This changes to check if the Jetpack class exists instead of checking if it's in the "active_plugins" table, that way it plays nice with mu plugins, not just locally installed plugins.